### PR TITLE
feature/allow-config-file

### DIFF
--- a/bin/careful
+++ b/bin/careful
@@ -1,5 +1,15 @@
 #! /usr/bin/env node
 
 var careful = require('../index')
+var options = {}
 
-process.exit(careful.validateBranchName(careful.currentBranch))
+const isConfigFileNameFlag = process.argv.findIndex((element) => {
+  return element === '--config-file';
+});
+
+if (isConfigFileNameFlag !== -1 && process.argv[isConfigFileNameFlag + 1]) {
+  const configFileName = process.argv[isConfigFileNameFlag + 1];
+  options.configFileName = configFileName;
+}
+
+process.exit(careful.validateBranchName(careful.currentBranch, options))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "careful",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Validate git branch names according to git-flow",
   "main": "index.js",
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 [![downloads](https://img.shields.io/npm/dm/careful.svg?style=flat-square)](http://npm-stat.com/charts.html?package=careful)
 [![MIT License](https://img.shields.io/npm/l/careful.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 
-Provides a binary that can be used as a `git-hook` to validate branch names according to `git-flow` prior to pushing upstream. 
+Provides a binary that can be used as a `git-hook` to validate branch names according to `git-flow` prior to pushing upstream.
 
 ```sh
 $ (features/banned-regex-support) careful
@@ -33,7 +33,7 @@ $ npm install careful --save-dev
 
 ### Options
 
-Define options in your `package.json` file (values displayed below are the default values):
+You can define options in your `package.json` file (values displayed below are the default values):
 
 ```javascript
 {
@@ -55,7 +55,7 @@ Define options in your `package.json` file (values displayed below are the defau
       // Skip validation check completely for certain branches
       // MUST be full branch name including prefixes
       "skip": [],
-      
+
       // Branches developers are disallowed to push code
       // MUST be full branch name including prefixes
       "disallowed": ["master", "staging", "develop"],
@@ -70,13 +70,15 @@ Define options in your `package.json` file (values displayed below are the defau
 }
 ```
 
+If you choose to put the configuration in external file use --config-file path/to/file.json.
+
 #### skip
 
 Skip all checks for certain branches.
 
 #### prefixes
 
-`git-flow` branch prefixes allowed. 
+`git-flow` branch prefixes allowed.
 
 #### suggestions
 


### PR DESCRIPTION
## WHATSUP
The configuration must be in the package.json file, which is cluttering the package.json. We need some way to allow usage of external configuration file (without breaking the module for people that choose to use package.json).

## BEFORE
No way to do it.

## AFTER
In the bin - detection of `--config-file` flag and pass it to `options.configFileName`.
I moved all the config parameters to init function with the options. From there it is pretty self explanatory. The init function calls loadConfiguration with the filename (if existed), loadConfiguration load all variables to `this` context. Every function can use it from now on.