### PR TITLE
Fix the missing separator error

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function doValidation (branch) {
   }
 
   if (branch.indexOf(SEPERATOR) < 0) {
-    return error(MSG_SEPERATOR_REQUIRED, branch)
+    return error(MSG_SEPERATOR_REQUIRED, branch, SEPERATOR)
   } else {
     parts = branch.split(SEPERATOR)
     prefix = parts[0].toLowerCase()


### PR DESCRIPTION
Currently, the missing separator check outputs

> CAREFUL! Branch "example" must contain a seperator "%s".

This is due to the second argument missing when the `error` function gets invoked